### PR TITLE
App factory deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn run_heroku:app
+web: gunicorn flagging_site:app:create_app()

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn flagging_site:app:create_app()
+web: gunicorn "flagging_site:app:create_app()"

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn "flagging_site:app:create_app()"
+web: gunicorn "flagging_site:create_app()"

--- a/run_heroku.py
+++ b/run_heroku.py
@@ -1,2 +1,0 @@
-from flagging_site import create_app
-app = create_app()


### PR DESCRIPTION
I recently learned that gunicorn supports the Flask app factory format, so the `run_heroku.py` script is unnecessary.

Usually I keep these PRs around and confirm with everyone that they're OK with it. In this particular case I'm going to just pull it in for the following four reasons:

- I'm already deploying the website with this new script;
- I am 100% confident this PR will not affect anyone's work flow right now;
- I don't think anyone here is very experience with gunicorn;
- As far as I can tell this is the preferred way to do this for app factories, which I hadn't realized until now.