### PR TITLE
Refactors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import os
 import pytest
 
 from flagging_site import create_app
-from flagging_site import config as _config
 
 
 @pytest.fixture(scope='session')
@@ -10,10 +9,8 @@ def app():
     """Create and configure a new app instance for each test."""
     if 'VAULT_PASSWORD' not in os.environ:
         os.environ['VAULT_PASSWORD'] = input('Enter vault password: ')
-        import importlib
-        importlib.reload(_config)
 
-    app = create_app(config=_config.TestingConfig())
+    app = create_app(config='testing')
 
     yield app
 
@@ -22,4 +19,3 @@ def app():
 def client(app):
     """A test client for the app."""
     return app.test_client()
-


### PR DESCRIPTION
Reorganized `app.py` to be much more legible by breaking the `create_app()` out into more organized units. `init_swagger` is also now in `api.py` because that's the only place that uses Swagger.

Other changes:

- `shell_context_processor` uses `locals()` to be more DRY
- `CustomJSONEncoder` is safer via subclassing the existing encoder.